### PR TITLE
Update compose.yml - correct Grafana health endpoint

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -67,7 +67,7 @@ services:
     ports:
       - ${GF_SERVER_HTTP_PORT}:3000
     healthcheck:
-      test: ["CMD", "wget", "--spider", "http://localhost:${GF_SERVER_HTTP_PORT}/healthz"]
+      test: ["CMD", "wget", "--spider", "http://localhost:${GF_SERVER_HTTP_PORT}/api/health"]
     environment:
       GF_LOG_LEVEL: ${GF_LOG_LEVEL}
       GF_AUTH_BASIC_ENABLED: true


### PR DESCRIPTION
Fix #4 

Grafana was using wrong endpoint for healthcheck and was pernamently marked as unhealthy in `docker ps`.

Endpoint changed [according to the documentation](https://grafana.com/docs/grafana/latest/developers/http_api/other/#health-api) to `/api/health`